### PR TITLE
feat: Add ApplicationInitialize class for initializing the application process

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,13 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_architecture_template/product/init/application_initialize.dart';
 import 'package:flutter_architecture_template/product/init/language/locale_keys.g.dart';
 import 'package:flutter_architecture_template/product/init/product_localization.dart';
 import 'package:flutter_architecture_template/product/utility/enums/locales.dart';
 
 void main() async{
-  WidgetsFlutterBinding.ensureInitialized();
-  await EasyLocalization.ensureInitialized();
-  
+
+  await ApplicationInitialize().make();
   runApp(
     ProductLocalization(child: MyApp()),
   );

--- a/lib/product/init/application_initialize.dart
+++ b/lib/product/init/application_initialize.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:kartal/kartal.dart';
+import 'package:logger/logger.dart';
+
+@immutable
+
+/// This class is used to initialize the application process.
+final class ApplicationInitialize {
+
+
+  /// Project basic required initialize
+  Future<void> make() async {
+    await runZonedGuarded<Future<void>>(_initialize, (error, stack) {
+      Logger().e(error.toString());
+    });
+  }
+
+  /// This method is used to initialize the application process.
+  static Future<void> _initialize() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await EasyLocalization.ensureInitialized();
+    /// Todo : Splash screen
+    await DeviceUtility.instance.initPackageInfo();
+
+    FlutterError.onError = (FlutterErrorDetails details) {
+      FlutterError.dumpErrorToConsole(details);
+
+      /// Crashlytics record error
+      /// custom service
+      /// Todo : add custom logger
+      Logger().e(details.exception.toString());
+
+      /// Dependency initialize
+      /// envied
+    };
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -542,7 +542,7 @@ packages:
     source: hosted
     version: "3.0.0"
   logger:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: logger
       sha256: "8c94b8c219e7e50194efc8771cd0e9f10807d8d3e219af473d89b06cc2ee4e04"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,8 +22,12 @@ dependencies:
 
   easy_localization: ^3.0.5
 
+  ## Utility
+  logger: ^2.2.0
+
   widgets:
     path: module/widgets
+ 
 
 
 dependency_overrides:


### PR DESCRIPTION


This commit introduces the ApplicationInitialize class in the lib/product/init/application_initialize.dart file to manage the initialization process of the application. The class provides essential methods for setting up the application environment and configurations.

Changes made:
- Created a new file: lib/product/init/application_initialize.dart
- Added the ApplicationInitialize class with methods for initialization.
- Modified lib/main.dart to integrate the ApplicationInitialize class for application startup.
- Updated dependencies in pubspec.yaml and regenerated pubspec.lock.

These changes enhance the maintainability and organization of the project by centralizing the initialization logic. This will make it easier to manage the application's startup process and improve code readability.